### PR TITLE
Add koa-tree-router, fix other routers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,15 @@
 Benchmark of the most commonly used http routers.
 
 Tested routers:
+
 - [find-my-way](https://github.com/delvedor/find-my-way)
 - [call](https://github.com/hapijs/call)
-- [routr](https://github.com/yahoo/routr)
-- [koa-router](https://github.com/alexmingoia/koa-router)
-- [router](https://github.com/pillarjs/router)
-- [server-router](https://github.com/yoshuawuyts/server-router)
 - [express](https://www.npmjs.com/package/express)
+- [koa-router](https://github.com/alexmingoia/koa-router)
+- [koa-tree-router](https://github.com/steambap/koa-tree-router)
+- [router](https://github.com/pillarjs/router)
+- [routr](https://github.com/yahoo/routr)
+- [server-router](https://github.com/yoshuawuyts/server-router)
 
 This benchmarks aims to test only http routers, so the method handling should be included.  
 Do you know other routers? [PR](https://github.com/delvedor/router-benchmark/pulls)! :D

--- a/benchmarks/express.js
+++ b/benchmarks/express.js
@@ -3,7 +3,7 @@
 const { title, now, print, operations } = require('../utils')
 const router = require('express/lib/router')()
 
-title('express benchmark')
+title('express benchmark (WARNING: includes handling)')
 
 const routes = [
   { method: 'GET', url: '/user' },

--- a/benchmarks/koa-router.js
+++ b/benchmarks/koa-router.js
@@ -1,9 +1,10 @@
 'use strict'
 
 const { title, now, print, operations } = require('../utils')
-const router = require('router')()
+const KoaRouter = require('koa-router')
+const router = new KoaRouter()
 
-title('router benchmark (WARNING: includes handling)')
+title('koa-router benchmark')
 
 const routes = [
   { method: 'GET', url: '/user' },
@@ -34,47 +35,47 @@ routes.forEach(route => {
 
 time = now()
 for (i = 0; i < operations; i++) {
-  router({ method: 'GET', url: '/user' }, null, noop)
+  router.match('/user', 'GET')
 }
 print('short static:', time)
 
 time = now()
 for (i = 0; i < operations; i++) {
-  router({ method: 'GET', url: '/user/comments' }, null, noop)
+  router.match('/user/comments', 'GET')
 }
 print('static with same radix:', time)
 
 time = now()
 for (i = 0; i < operations; i++) {
-  router({ method: 'GET', url: '/user/lookup/username/john' }, null, noop)
+  router.match('/user/lookup/username/john', 'GET')
 }
 print('dynamic route:', time)
 
 time = now()
 for (i = 0; i < operations; i++) {
-  router({ method: 'GET', url: '/event/abcd1234/comments' }, null, noop)
+  router.match('/event/abcd1234/comments', 'GET')
 }
 print('mixed static dynamic:', time)
 
 time = now()
 for (i = 0; i < operations; i++) {
-  router({ method: 'GET', url: '/very/deeply/nested/route/hello/there' }, null, noop)
+  router.match('/very/deeply/nested/route/hello/there', 'GET')
 }
 print('long static:', time)
 
 time = now()
 for (i = 0; i < operations; i++) {
-  router({ method: 'GET', url: '/static/index.html' }, null, noop)
+  router.match('/static/index.html', 'GET')
 }
 print('wildcard:', time)
 
 time = now()
 for (i = 0; i < operations; i++) {
-  router({ method: 'GET', url: '/user' }, null, noop)
-  router({ method: 'GET', url: '/user/comments' }, null, noop)
-  router({ method: 'GET', url: '/user/lookup/username/john' }, null, noop)
-  router({ method: 'GET', url: '/event/abcd1234/comments' }, null, noop)
-  router({ method: 'GET', url: '/very/deeply/nested/route/hello/there' }, null, noop)
-  router({ method: 'GET', url: '/static/index.html' }, null, noop)
+  router.match('/user', 'GET')
+  router.match('/user/comments', 'GET')
+  router.match('/user/lookup/username/john', 'GET')
+  router.match('/event/abcd1234/comments', 'GET')
+  router.match('/very/deeply/nested/route/hello/there', 'GET')
+  router.match('/static/index.html', 'GET')
 }
 print('all together:', time)

--- a/benchmarks/koa-tree-router.js
+++ b/benchmarks/koa-tree-router.js
@@ -1,10 +1,9 @@
 'use strict'
 
 const { title, now, print, operations } = require('../utils')
-const KoaRouter = require('koa-router')
-const router = new KoaRouter()
+const router = require('koa-tree-router')()
 
-title('koa benchmark')
+title('koa-tree-router benchmark')
 
 const routes = [
   { method: 'GET', url: '/user' },
@@ -18,64 +17,60 @@ const routes = [
   { method: 'GET', url: '/map/:location/events' },
   { method: 'GET', url: '/status' },
   { method: 'GET', url: '/very/deeply/nested/route/hello/there' },
-  { method: 'GET', url: '/static/*' }
+  { method: 'GET', url: '/static/*file' }
 ]
 
 function noop () {}
 var i = 0
 var time = 0
 
-routes.forEach(route => {
-  if (route.method === 'GET') {
-    router.get(route.url, noop)
-  } else {
-    router.post(route.url, noop)
-  }
+routes.forEach(({ method, url }) => {
+  router.on(method, url, noop)
 })
 
 time = now()
 for (i = 0; i < operations; i++) {
-  router.url('/user')
+  router.find('GET', '/user')
 }
 print('short static:', time)
 
 time = now()
 for (i = 0; i < operations; i++) {
-  router.url('/user/comments')
+  router.find('GET', '/user/comments')
 }
 print('static with same radix:', time)
 
 time = now()
 for (i = 0; i < operations; i++) {
-  router.url('/user/lookup/username/john')
+  router.find('GET', '/user/lookup/username/john')
 }
 print('dynamic route:', time)
 
 time = now()
 for (i = 0; i < operations; i++) {
-  router.url('/event/abcd1234/comments')
+  router.find('GET', '/event/abcd1234/comments')
 }
 print('mixed static dynamic:', time)
 
 time = now()
 for (i = 0; i < operations; i++) {
-  router.url('/very/deeply/nested/route/hello/there')
+  router.find('GET', '/very/deeply/nested/route/hello/there')
 }
 print('long static:', time)
 
 time = now()
 for (i = 0; i < operations; i++) {
-  router.url('/static/index.html')
+  router.find('GET', '/static/index.html')
 }
 print('wildcard:', time)
 
 time = now()
 for (i = 0; i < operations; i++) {
-  router.url('/user')
-  router.url('/user/comments')
-  router.url('/user/lookup/username/john')
-  router.url('/event/abcd1234/comments')
-  router.url('/very/deeply/nested/route/hello/there')
-  router.url('/static/index.html')
+  router.find('GET', '/user')
+  router.find('GET', '/user/comments')
+  router.find('GET', '/user/lookup/username/john')
+  router.find('GET', '/event/abcd1234/comments')
+  router.find('GET', '/very/deeply/nested/route/hello/there')
+  router.find('GET', '/static/index.html')
 }
 print('all together:', time)

--- a/benchmarks/server-router.js
+++ b/benchmarks/server-router.js
@@ -30,47 +30,47 @@ routes.forEach(route => {
 
 time = now()
 for (i = 0; i < operations; i++) {
-  router.match({ method: 'GET', url: '/user' })
+  router._router.match('GET/user')
 }
 print('short static:', time)
 
 time = now()
 for (i = 0; i < operations; i++) {
-  router.match({ method: 'GET', url: '/user/comments' })
+  router._router.match('GET/user/comments')
 }
 print('static with same radix:', time)
 
 time = now()
 for (i = 0; i < operations; i++) {
-  router.match({ method: 'GET', url: '/user/lookup/username/john' })
+  router._router.match('GET/user/lookup/username/john')
 }
 print('dynamic route:', time)
 
 time = now()
 for (i = 0; i < operations; i++) {
-  router.match({ method: 'GET', url: '/event/abcd1234/comments' }, null)
+  router._router.match('GET/event/abcd1234/comments')
 }
 print('mixed static dynamic:', time)
 
 time = now()
 for (i = 0; i < operations; i++) {
-  router.match({ method: 'GET', url: '/very/deeply/nested/route/hello/there' }, null)
+  router._router.match('GET/very/deeply/nested/route/hello/there')
 }
 print('long static:', time)
 
 time = now()
 for (i = 0; i < operations; i++) {
-  router.match({ method: 'GET', url: '/static/index.html' }, null)
+  router._router.match('GET/static/index.html')
 }
 print('wildcard:', time)
 
 time = now()
 for (i = 0; i < operations; i++) {
-  router.match({ method: 'GET', url: '/user' })
-  router.match({ method: 'GET', url: '/user/comments' })
-  router.match({ method: 'GET', url: '/user/lookup/username/john' })
-  router.match({ method: 'GET', url: '/event/abcd1234/comments' }, null)
-  router.match({ method: 'GET', url: '/very/deeply/nested/route/hello/there' }, null)
-  router.match({ method: 'GET', url: '/static/index.html' }, null)
+  router._router.match('GET/user')
+  router._router.match('GET/user/comments')
+  router._router.match('GET/user/lookup/username/john')
+  router._router.match('GET/event/abcd1234/comments')
+  router._router.match('GET/very/deeply/nested/route/hello/there')
+  router._router.match('GET/static/index.html')
 }
 print('all together:', time)

--- a/package.json
+++ b/package.json
@@ -12,10 +12,11 @@
   "author": "Tomas Della Vedova - @delvedor (http://delved.org)",
   "license": "MIT",
   "dependencies": {
-    "call": "^5.0.0",
+    "call": "^5.0.1",
     "express": "^4.16.2",
-    "find-my-way": "^1.7.0",
-    "koa-router": "^7.2.1",
+    "find-my-way": "^1.10.1",
+    "koa-router": "^7.4.0",
+    "koa-tree-router": "^0.2.2",
     "router": "^1.3.2",
     "routr": "^2.1.0",
     "server-router": "^6.0.0"

--- a/runner.js
+++ b/runner.js
@@ -8,10 +8,11 @@ const benchmarks = [
   'find-my-way.js',
   'call.js',
   'express.js',
-  'koa.js',
+  'koa-router.js',
+  'koa-tree-router.js',
+  'router.js',
   'routr.js',
-  'server-router.js',
-  'router.js'
+  'server-router.js'
 ]
 
 const queue = new Queue()


### PR DESCRIPTION
Added [`koa-tree-router`](https://github.com/steambap/koa-tree-router), since I was curious how it stacks up against `koa-router` and `find-my-way`. The results on my i7-8550U CPU + 1866MHz RAM + Linux 4.15 + Node 9.6 are at the end of this post. Please, let me know if you're okay with me replacing the ones in the `README.md` with these.

While doing that, I have noticed a few issues.

The biggest one is the fact that the only apples-to-apples benchmarks are `call`, `find-my-way` and `routr`. The rest are doing extra work (handling and such) and `koa-router` is outright invalid. I have attempted fixing what I could, and added a warning where it isn't possible (can't decouple lookup from handling in `express` and `router`). Could do the opposite (i.e. include handling in all tests), but that isn't framework-agnostic, and clearly isn't your intent, since the router you're the creator of - `find-my-way` - isn't doing that in its benchmark. On the other hand, how does one compare it to `express` in a fair way then?

Another important issue is the fact that this suite isn't very consistent/accurate, measurement-wise. I see you're [using `benchmark` in `find-my-way`](https://github.com/delvedor/find-my-way/blob/ba04e309b28b64f18fe6a535b6dad5e1ee1f89e8/bench.js), why not use it here? And on a related note, would be nice to have a right-aligned sorted list of "all together" ops/sec from all routers, and possibly an accompanying bar graph, and some sort of overall "editorial" ranking.

Lastly, the benchmarks are way too WET. Have you considered taking a more declarative approach? Have a preparation step, transforming a common `routes` list (probably express-style, since half the routers support it as-is) into a router-specific format, and then an execution step, invoking a given lookup function with the method and path passed, again, in a router-specific manner. Otherwise I can see subtle differences starting to creep in between the benchmarks, as more of them are being added/updated, skewing the results.

Without addressing the above, IMO, this suite shouldn't be used as `find-my-way`'s advertisement.

```
=======================
 find-my-way benchmark
=======================
short static: 13,810,332 ops/sec
static with same radix: 6,273,479 ops/sec
dynamic route: 1,682,494 ops/sec
mixed static dynamic: 2,006,188 ops/sec
long static: 8,335,677 ops/sec
wildcard: 2,693,026 ops/sec
all together: 498,427 ops/sec

================
 call benchmark
================
short static: 3,700,535 ops/sec
static with same radix: 3,598,872 ops/sec
dynamic route: 792,128 ops/sec
mixed static dynamic: 862,072 ops/sec
long static: 3,763,495 ops/sec
wildcard: 1,292,482 ops/sec
all together: 232,753 ops/sec

================================================
 express benchmark (WARNING: includes handling)
================================================
short static: 1,217,991 ops/sec
static with same radix: 1,134,697 ops/sec
dynamic route: 723,241 ops/sec
mixed static dynamic: 628,484 ops/sec
long static: 636,273 ops/sec
wildcard: 500,932 ops/sec
all together: 105,345 ops/sec

======================
 koa-router benchmark
======================
short static: 1,137,411 ops/sec
static with same radix: 1,172,908 ops/sec
dynamic route: 1,115,376 ops/sec
mixed static dynamic: 1,101,533 ops/sec
long static: 1,179,059 ops/sec
wildcard: 1,117,365 ops/sec
all together: 177,765 ops/sec

===========================
 koa-tree-router benchmark
===========================
short static: 12,929,070 ops/sec
static with same radix: 6,047,950 ops/sec
dynamic route: 2,984,655 ops/sec
mixed static dynamic: 3,787,085 ops/sec
long static: 7,840,458 ops/sec
wildcard: 4,106,017 ops/sec
all together: 781,418 ops/sec

===============================================
 router benchmark (WARNING: includes handling)
===============================================
short static: 1,176,093 ops/sec
static with same radix: 1,045,083 ops/sec
dynamic route: 685,231 ops/sec
mixed static dynamic: 589,179 ops/sec
long static: 623,477 ops/sec
wildcard: 467,692 ops/sec
all together: 94,245 ops/sec

=================
 routr benchmark
=================
short static: 3,951,940 ops/sec
static with same radix: 1,975,343 ops/sec
dynamic route: 853,571 ops/sec
mixed static dynamic: 537,769 ops/sec
long static: 409,445 ops/sec
wildcard: 323,400 ops/sec
all together: 101,739 ops/sec

=========================
 server-router benchmark
=========================
short static: 2,837,363 ops/sec
static with same radix: 2,902,904 ops/sec
dynamic route: 1,677,476 ops/sec
mixed static dynamic: 1,807,669 ops/sec
long static: 1,849,464 ops/sec
wildcard: 1,454,016 ops/sec
all together: 284,792 ops/sec
```