### PR TITLE
Add Anumargak router for comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Benchmark of the most commonly used http routers.
 Tested routers:
 
 - [find-my-way](https://github.com/delvedor/find-my-way)
+- [anumargak](https://github.com/NaturalIntelligence/anumargak)
 - [call](https://github.com/hapijs/call)
 - [express](https://www.npmjs.com/package/express)
 - [koa-router](https://github.com/alexmingoia/koa-router)
@@ -139,6 +140,7 @@ npm start
 | Router | Framework independent    | Decode URI    | Querystring handling   |  Regex route support | Multi-parametric route support |  Max parameter length |
 | :------------ | :------------ | :------------ | :--------------------- | :------------------- |:------------------------------ |:--------------------- |
 | `find-my-way` | &#10003; | &#10003; | &#10003; | &#10003; | &#10003; | &#10003; |
+| `anumargak` | &#10003; | &#10003; | &#10003; | &#10003; | &#10003; | &#10007; |
 | `call` | &#10003;  | &#10003; | &#10007; | ? | ? | ? |
 | `express` | &#10007;  | &#10003; | &#10003; | &#10003; | &#10003; | &#10007; |
 | `koa-router` | &#10007;  | &#10007; | &#10007; | &#10003; | &#10003; | &#10007; |

--- a/benchmarks/anumargak.js
+++ b/benchmarks/anumargak.js
@@ -1,0 +1,76 @@
+'use strict'
+
+const { title, now, print, operations } = require('../utils')
+const router = require('anumargak')()
+
+title('anumargak benchmark')
+
+const routes = [
+  { method: 'GET', url: '/user' },
+  { method: 'GET', url: '/user/comments' },
+  { method: 'GET', url: '/user/avatar' },
+  { method: 'GET', url: '/user/lookup/username/:username' },
+  { method: 'GET', url: '/user/lookup/email/:address' },
+  { method: 'GET', url: '/event/:id' },
+  { method: 'GET', url: '/event/:id/comments' },
+  { method: 'POST', url: '/event/:id/comment' },
+  { method: 'GET', url: '/map/:location/events' },
+  { method: 'GET', url: '/status' },
+  { method: 'GET', url: '/very/deeply/nested/route/hello/there' },
+  { method: 'GET', url: '/static/*' }
+]
+
+function noop () {}
+var i = 0
+var time = 0
+
+routes.forEach(route => {
+  router.on(route.method, route.url, noop)
+})
+
+time = now()
+for (i = 0; i < operations; i++) {
+  router.find('GET', '/user')
+}
+print('short static:', time)
+
+time = now()
+for (i = 0; i < operations; i++) {
+  router.find('GET', '/user/comments')
+}
+print('static with same radix:', time)
+
+time = now()
+for (i = 0; i < operations; i++) {
+  router.find('GET', '/user/lookup/username/john')
+}
+print('dynamic route:', time)
+
+time = now()
+for (i = 0; i < operations; i++) {
+  router.find('GET', '/event/abcd1234/comments')
+}
+print('mixed static dynamic:', time)
+
+time = now()
+for (i = 0; i < operations; i++) {
+  router.find('GET', '/very/deeply/nested/route/hello/there')
+}
+print('long static:', time)
+
+time = now()
+for (i = 0; i < operations; i++) {
+  router.find('GET', '/static/index.html')
+}
+print('wildcard:', time)
+
+time = now()
+for (i = 0; i < operations; i++) {
+  router.find('GET', '/user')
+  router.find('GET', '/user/comments')
+  router.find('GET', '/user/lookup/username/john')
+  router.find('GET', '/event/abcd1234/comments')
+  router.find('GET', '/very/deeply/nested/route/hello/there')
+  router.find('GET', '/static/index.html')
+}
+print('all together:', time)

--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
   "author": "Tomas Della Vedova - @delvedor (http://delved.org)",
   "license": "MIT",
   "dependencies": {
+    "anumargak": "^1.3.0",
     "call": "^5.0.1",
     "express": "^4.16.3",
-    "find-my-way": "^1.11.0",
+    "find-my-way": "^1.12.0",
     "koa-router": "^7.4.0",
     "koa-tree-router": "^0.2.2",
     "router": "^1.3.2",

--- a/runner.js
+++ b/runner.js
@@ -6,6 +6,7 @@ const { Queue } = require('./utils')
 
 const benchmarks = [
   'find-my-way.js',
+  'anumargak.js',
   'call.js',
   'express.js',
   'koa-router.js',


### PR DESCRIPTION
Please accept the PR to add [Anumargak](https://github.com/NaturalIntelligence/anumargak) router. I've not updated the result on README because

* Somehow express was not being installed on my machine
* Everyone has different machine so different results..

However here is report from my machine (ubuntu 17.10, i7, 16GB, node v9.10.1, npm v5.8.0)

```
=======================
 find-my-way benchmark
=======================
short static: 10,498,625 ops/sec
static with same radix: 3,861,088 ops/sec
dynamic route: 1,366,492 ops/sec
mixed static dynamic: 1,952,055 ops/sec
long static: 6,146,350 ops/sec
wildcard: 2,720,057 ops/sec
all together: 462,154 ops/sec

=====================
 anumargak benchmark
=====================
short static: 20,731,932 ops/sec
static with same radix: 30,583,395 ops/sec
dynamic route: 9,088,856 ops/sec
mixed static dynamic: 4,029,118 ops/sec
long static: 31,527,839 ops/sec
wildcard: 3,538,916 ops/sec
all together: 1,312,540 ops/sec

================
 call benchmark
================
short static: 3,715,259 ops/sec
static with same radix: 3,802,896 ops/sec
dynamic route: 816,136 ops/sec
mixed static dynamic: 876,621 ops/sec
long static: 4,115,237 ops/sec
wildcard: 1,346,504 ops/sec
all together: 250,349 ops/sec

======================
 koa-router benchmark
======================
short static: 1,185,294 ops/sec
static with same radix: 1,217,684 ops/sec
dynamic route: 1,135,935 ops/sec
mixed static dynamic: 1,119,404 ops/sec
long static: 1,201,539 ops/sec
wildcard: 1,154,779 ops/sec
all together: 184,463 ops/sec

===========================
 koa-tree-router benchmark
===========================
short static: 13,596,453 ops/sec
static with same radix: 6,631,522 ops/sec
dynamic route: 3,232,589 ops/sec
mixed static dynamic: 3,835,127 ops/sec
long static: 8,316,111 ops/sec
wildcard: 4,428,353 ops/sec
all together: 864,198 ops/sec

===============================================
 router benchmark (WARNING: includes handling)
===============================================
short static: 1,186,380 ops/sec
static with same radix: 1,092,566 ops/sec
dynamic route: 692,150 ops/sec
mixed static dynamic: 612,234 ops/sec
long static: 621,997 ops/sec
wildcard: 497,708 ops/sec
all together: 114,670 ops/sec

=================
 routr benchmark
=================
short static: 3,795,356 ops/sec
static with same radix: 1,905,451 ops/sec
dynamic route: 838,607 ops/sec
mixed static dynamic: 541,265 ops/sec
long static: 407,290 ops/sec
wildcard: 327,995 ops/sec
all together: 101,198 ops/sec

=========================
 server-router benchmark
=========================
short static: 2,866,262 ops/sec
static with same radix: 2,854,169 ops/sec
dynamic route: 1,772,911 ops/sec
mixed static dynamic: 1,799,525 ops/sec
long static: 1,944,810 ops/sec
wildcard: 1,472,171 ops/sec
all together: 291,769 ops/sec

=======================
 trek-router benchmark
=======================
short static: 9,885,615 ops/sec
static with same radix: 5,112,651 ops/sec
dynamic route: 1,812,229 ops/sec
mixed static dynamic: 2,259,349 ops/sec
long static: 8,090,141 ops/sec
wildcard: 3,499,804 ops/sec
all together: 537,065 ops/sec

```